### PR TITLE
Movendo api properties

### DIFF
--- a/src/routes/games/games.controller.ts
+++ b/src/routes/games/games.controller.ts
@@ -21,7 +21,7 @@ import {
 import { JwtAuthGuard } from 'src/auth/auth.guard';
 import { Category } from '../categories/categories.entity';
 import { Language } from '../languages/languages.entity';
-import { GameDto, QueryParamsDto } from './games.dto';
+import { GameDto, idDto, QueryParamsDto } from './games.dto';
 import { Game, Question } from './games.entity';
 import { GamesService } from './games.service';
 
@@ -58,13 +58,8 @@ export class GamesController {
   @ApiOperation({
     description: 'Endpoint que retorna um jogo do usuário logado',
   })
-  @ApiParam({
-    name: 'id',
-    description: 'ID do jogo',
-    required: true,
-  })
   @Get(':id')
-  async get(@Param() params, @Request() req) {
+  async get(@Param() params: idDto, @Request() req) {
     const game = await this.gamesService.findOneByUser(params.id, req.user);
     if (game === undefined) {
       throw new NotFoundException('Jogo não encontrado');
@@ -105,13 +100,8 @@ export class GamesController {
   @ApiOperation({
     description: 'Endpoint para excluir um jogo do usuário logado',
   })
-  @ApiParam({
-    name: 'id',
-    description: 'ID do jogo',
-    required: true,
-  })
   @Delete(':id')
-  async delete(@Param() params, @Request() req) {
+  async delete(@Param() params: idDto, @Request() req) {
     const game = new Game();
     game.id = params.id;
     game.user = req.user;
@@ -127,13 +117,8 @@ export class GamesController {
   @ApiOperation({
     description: 'Endpoint para duplicar um jogo do usuario logado',
   })
-  @ApiParam({
-    name: 'id',
-    description: 'ID do jogo',
-    required: true,
-  })
   @Post('duplicate/:id')
-  async duplicate(@Param() params, @Request() req) {
+  async duplicate(@Param() params: idDto, @Request() req) {
     const game = await this.gamesService.find(params.id);
     if (game === undefined) {
       throw new NotFoundException('Jogo não encontrado');
@@ -148,13 +133,8 @@ export class GamesController {
   @ApiOperation({
     description: 'Endpoint para editar um jogo do usuario logado',
   })
-  @ApiParam({
-    name: 'id',
-    description: 'ID do jogo',
-    required: true,
-  })
   @Put(':id')
-  async editGame(@Param() param, @Body() dto: GameDto, @Request() req) {
+  async editGame(@Param() param: idDto, @Body() dto: GameDto, @Request() req) {
     const game = await this.gamesService.findOneByUser(param.id, req.user);
 
     if (game === undefined) {

--- a/src/routes/games/games.controller.ts
+++ b/src/routes/games/games.controller.ts
@@ -12,12 +12,7 @@ import {
   Request,
   UseGuards,
 } from '@nestjs/common';
-import {
-  ApiBearerAuth,
-  ApiOperation,
-  ApiParam,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/auth.guard';
 import { Category } from '../categories/categories.entity';
 import { Language } from '../languages/languages.entity';

--- a/src/routes/games/games.dto.ts
+++ b/src/routes/games/games.dto.ts
@@ -5,6 +5,7 @@ import {
   IsArray,
   IsNotEmpty,
   IsNumber,
+  IsNumberString,
   IsOptional,
   IsPositive,
   IsString,
@@ -104,8 +105,7 @@ export class QueryParamsDto {
     required: false,
   })
   @IsOptional()
-  @IsNumber()
-  @IsPositive()
+  @IsNumberString()
   language: number;
 
   @ApiProperty({
@@ -114,8 +114,7 @@ export class QueryParamsDto {
     required: false,
   })
   @IsOptional()
-  @IsNumber()
-  @IsPositive()
+  @IsNumberString()
   category: number;
 
   @ApiProperty({
@@ -124,7 +123,15 @@ export class QueryParamsDto {
     required: false,
   })
   @IsOptional()
-  @IsNumber()
-  @IsPositive()
+  @IsNumberString()
   limit: number;
+}
+export class idDto{
+  @ApiProperty({
+    name: 'id',
+    description: 'ID do jogo',
+    required: true,
+  })
+  @IsNumberString()
+  id: number;
 }

--- a/src/routes/games/games.dto.ts
+++ b/src/routes/games/games.dto.ts
@@ -126,7 +126,7 @@ export class QueryParamsDto {
   @IsNumberString()
   limit: number;
 }
-export class idDto{
+export class idDto {
   @ApiProperty({
     name: 'id',
     description: 'ID do jogo',


### PR DESCRIPTION
Foi removido os ApiParams do games controllers, substituido por um tipo idDto, visto que a mesma operação( colocar a descrição do id) se repetia para mais de 2 endpoints


Na hora de testar, o games/community estava dando erro de tipos, pois a query enviava strings numericas, e a verificação era @IsNumber/@IsPositive, por isso o erro, troquei todos por @IsNumberString, testei e mesmo enviando numeros negativos, o retorno e correto, sendo nulo nesses casos