### PR TITLE
Implementando o nivel de permissão

### DIFF
--- a/src/endpoints/mails/index.mjs
+++ b/src/endpoints/mails/index.mjs
@@ -57,6 +57,16 @@ export const handler = async (event) => {
             const sesClient = new SESClient({ region: 'us-east-1' });
             const fromMail = process.env.SUPPORT_EMAIL;
             const redirectLink = process.env.REDIRECT_LINK;
+            const user_who_invited = event.requestContext.authorizer.lambda.user
+
+            let convitedby = await conn.query({
+                name: "selectConvitedBy",
+                text: "SELECT permission_level FROM users WHERE id = $1",
+                values: [
+                    user_who_invited
+                ],
+            });
+            let permission_user_who_invited = convitedby.rows[0].permission_level
 
             let situations = {
                 0:"Em espera de envio",
@@ -92,6 +102,18 @@ export const handler = async (event) => {
             switch (event.routeKey){
                 case "POST /mails/registermail":{
 
+                    if ( permission_user_who_invited > 2){
+                        return {
+                            statusCode: 403,
+                            body: JSON.stringify({
+                                statusCode: 403,
+                                status: "Forbidden",
+                                errorCode: 1,
+                                error: "Nivel de permissão insuficiente!",
+                            }),
+                        };
+                    }
+
                     if (!validaEmail(body["email"])){
                         return {
                             statusCode: 400,
@@ -117,10 +139,11 @@ export const handler = async (event) => {
                     try {
                         results = await conn.query({
                             name: "registerEmail",
-                            text: 'INSERT INTO email_controller ("email", "situation", "createdAt", "updatedAt") VALUES ($1, $2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) RETURNING id',
+                            text: 'INSERT INTO email_controller ("email", "situation", "createdAt", "updatedAt", "convitedby") VALUES ($1, $2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $3) RETURNING id',
                             values: [
                                 body.email,
-                                1 // {0:"Em espera de envio",1:"Email enviado", 2:"Enviado e usuario cadastrado"}
+                                1, // {0:"Em espera de envio",1:"Email enviado", 2:"Enviado e usuario cadastrado"}
+                                user_who_invited
                             ],
                         });
                     } catch (e) {
@@ -189,6 +212,19 @@ export const handler = async (event) => {
                 }
                 case "POST /mails/invite": {
                     const body = JSON.parse(event.body);
+
+                    if ( permission_user_who_invited > 2){
+                        return {
+                            statusCode: 403,
+                            body: JSON.stringify({
+                                statusCode: 403,
+                                status: "Forbidden",
+                                errorCode: 1,
+                                error: "Nivel de permissão insuficiente!",
+                            }),
+                        };
+                    }
+
 
                     if (!body.emails){
                         return {

--- a/src/endpoints/register/index.mjs
+++ b/src/endpoints/register/index.mjs
@@ -89,7 +89,7 @@ export const handler = async (event) => {
 
                         results = await conn.query({
                             name: "verifyemail",
-                            text: 'SELECT email FROM email_controller WHERE email = $1',
+                            text: 'SELECT email, convitedby FROM email_controller WHERE email = $1 and situation = 1',
                             values: [
                                 body.email,
                             ],
@@ -107,12 +107,20 @@ export const handler = async (event) => {
                             };
                         }
 
+                        results = await conn.query({
+                            name: "permissionlevel",
+                            text: 'SELECT permission_level FROM users WHERE id = $1',
+                            values: [
+                                results.rows[0].convitedby,
+                            ],
+                        });
+
                         try {
                             const password_hash = bcrypt.hashSync(body["password"], 10);
 
                             results = await conn.query({
                                 name: "register",
-                                text: 'INSERT INTO users ("name", "email", "password", "institution", "city", "work_type", "education_level", "status") VALUES ($1, $2, $3, $4, $5, $6, $7, 1) RETURNING id',
+                                text: 'INSERT INTO users ("name", "email", "password", "institution", "city", "work_type", "education_level", "status", "permission_level") VALUES ($1, $2, $3, $4, $5, $6, $7, 1, $8) RETURNING id',
                                 values: [
                                     body.name,
                                     body.email,
@@ -121,6 +129,7 @@ export const handler = async (event) => {
                                     body.city,
                                     body.workType,
                                     body.educationLevel,
+                                    results.rows[0].permission_level+1,
                                 ],
                             });
                         } catch (e) {
@@ -133,7 +142,17 @@ export const handler = async (event) => {
                                         statusCode: 400,
                                         status: "Bad Request",
                                         errorCode: 2,
-                                        error: "Email already registered",
+                                        error: "Email ja registrado!",
+                                    })
+                                };
+                            } else {
+                                return {
+                                    statusCode: 500,
+                                    body: JSON.stringify({
+                                        statusCode: 500,
+                                        status: "Bad Request",
+                                        errorCode: 6589,
+                                        error: "Um erro inesperado ocorreu, cod 6589!!",
                                     })
                                 };
                             }


### PR DESCRIPTION
apenas gestores (2) e super usuarios(1), podem convidar outros para a plataforma.

Logica:
- ao convidar alguem salvamos o id de quem convidou, na email_controller
- quando a pessoa for se cadastrar, pegamos o nivel de permissão de quem a convidou e damos a classe com menos privilegios (imediatamente abaixo da classe de quem convidou)

Assim super usuarios convidam gestores e gestores convidam usuarios comuns, e usuarios comuns não convidam ninguem.